### PR TITLE
Fix specialty bonus on base salary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 26.5.17
 * Add base salary row
+* Fix specialty bonus so it only applies to the skill-derived wage, not the fixed base salary (ref: https://www.hattrick.org/Forum/Read.aspx?t=17629498&v=4&a=1&n=237)
 
 ## 26.3.12
 * Better support of multiple teams

--- a/src/engine.js
+++ b/src/engine.js
@@ -116,8 +116,9 @@ function setMinAndMaxSalary(player) {
     min += player.WageWizard.Skills[skill].min;
     max += player.WageWizard.Skills[skill].max;
   }
-  let baseSalary = player.Special ? 1.1 * BASE_SALARY : BASE_SALARY;
-  baseSalary = player.Abroad ? 1.2 * baseSalary : baseSalary;
+  // Specialty only affects the skill-derived wage portion; the fixed base salary
+  // only receives the abroad bonus. Ref: https://www.hattrick.org/Forum/Read.aspx?t=17629498&v=4&a=1&n=237
+  const baseSalary = player.Abroad ? 1.2 * BASE_SALARY : BASE_SALARY;
   player.WageWizard.baseSalary = baseSalary;
   player.WageWizard.min =
     baseSalary + min * player.WageWizard.Skills.SetPiecesSkill.min;

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -194,7 +194,7 @@ describe("setPlayerData", () => {
     expect(player.WageWizard.abroadSeasonly).toBe(16000);
   });
 
-  it("applies special bonus", () => {
+  it("applies special bonus without inflating base salary", () => {
     const player = {
       Age: 25,
       Salary: "5000",
@@ -209,10 +209,30 @@ describe("setPlayerData", () => {
       ScorerSkill: 3,
     };
     setPlayerData(player);
-    expect(player.WageWizard.baseSalary).toBe(2750);
+    expect(player.WageWizard.baseSalary).toBe(2500);
     expect(player.WageWizard.specialWeekly).toBe(500);
     expect(player.WageWizard.specialSeasonly).toBe(8000);
     expect(player.WageWizard.abroadWeekly).toBe(0);
+  });
+
+  it("keeps the fixed base salary on the abroad path as well", () => {
+    const player = {
+      Age: 25,
+      Salary: "5000",
+      Special: true,
+      Abroad: true,
+      KeeperSkill: 1,
+      SetPiecesSkill: 5,
+      DefenderSkill: 10,
+      PlaymakerSkill: 8,
+      PassingSkill: 6,
+      WingerSkill: 4,
+      ScorerSkill: 3,
+    };
+    setPlayerData(player);
+    expect(player.WageWizard.baseSalary).toBe(3000);
+    expect(player.WageWizard.abroadWeekly).toBe(1000);
+    expect(player.WageWizard.specialWeekly).toBe(500);
   });
 
   it("shows zero special bonus when not special", () => {


### PR DESCRIPTION
The specialty bonus should only affect the skill-derived wage portion. Keep the fixed base salary unchanged, except for the existing abroad bonus.

Add regression coverage for special-only and special-plus-abroad players, and record the Hattrick forum reference in the changelog for future formula checks.

Refs:
- https://www.hattrick.org/Forum/Read.aspx?t=17681872
- https://www.hattrick.org/Forum/Read.aspx?t=17629498&v=4&a=1&n=237